### PR TITLE
Join session failure no longer crashes program

### DIFF
--- a/frontend/src/components/app.js
+++ b/frontend/src/components/app.js
@@ -111,18 +111,27 @@ class App extends React.Component {
   connectSocket(name) {
     console.log('connecting socket');
     this.isHost = false;
-    const sessionId = this.props.users[name]._id;
-    console.log(`Session ID: ${sessionId}`);
-    this.joinSocket(sessionId);
+    const user = this.props.users[name];
+    console.log(`Connecting to user: ${user}`);
+    if (user) {
+      const sessionId = this.props.users[name]._id;
+      console.log(`Session ID: ${sessionId}`);
+      this.joinSocket(sessionId);
+      return true;
+    } else {
+      return false;
+    }
     // this.forceUpdate();
   }
 
   send(data) {
     // this.child.testMethod();
-    if (this.isHost) {
-      this.emit('From Host GameState', data);
-    } else {
-      this.emit('From Client Input', data);
+    if (this.emit) {
+      if (this.isHost) {
+        this.emit('From Host GameState', data);
+      } else {
+        this.emit('From Client Input', data);
+      }
     }
   }
 

--- a/frontend/src/components/game/join_game_session.js
+++ b/frontend/src/components/game/join_game_session.js
@@ -29,10 +29,9 @@ class GameSession extends React.Component {
         this.props.index().then((users) => {
             let username = this.state.value;
             // console.log(username)
-            console.log(users);
-            this.props.connectSocket(username);
+            const result = this.props.connectSocket(username);
             // give the name, connectsocket gets the sessionid using the name
-            this.props.history.push('/game');
+            if (result) this.props.history.push('/game');
         })
     }
 


### PR DESCRIPTION
Capture this.emit problem, forcing user to recreate their session, and handling invalid user input for trying to join a user that does not exist. (Refuse the socket connection attempt)